### PR TITLE
Remove :lang(mn) rules in emphasis marks tests

### DIFF
--- a/css-text-decor/emphasis-marks/text-emphasis-001.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-001.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-002.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-002.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-003.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-003.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-004.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-004.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-005.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-005.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-006.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-006.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-007.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-007.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-008.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-008.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-009.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-009.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-010.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-010.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-011.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-011.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-012.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-012.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-014.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-014.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-015.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-015.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-016.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-016.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-017.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-017.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-018.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-018.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-019.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-019.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-020.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-020.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-position-001.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-position-001.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-position-002.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-position-002.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-position-003.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-position-003.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-position-004.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-position-004.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-position-005.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-position-005.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-position-006.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-position-006.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-position-007.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-position-007.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-position-008.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-position-008.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-position-009.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-position-009.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-position-010.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-position-010.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-position-011.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-position-011.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-position-012.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-position-012.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-001.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-001.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-002.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-002.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-003.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-003.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-004.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-004.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-005.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-005.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-006.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-006.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-007.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-007.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-008.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-008.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-009.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-009.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-010.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-010.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-011.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-011.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-012.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-012.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-014.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-014.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-015.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-015.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-016.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-016.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-017.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-017.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-018.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-018.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-019.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-019.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-020.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-020.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-001.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-001.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-002.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-002.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-003.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-003.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-004.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-004.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-005.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-005.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-006.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-006.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-007.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-007.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-008.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-008.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-009.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-009.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-010.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-010.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-011.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-011.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-012.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-012.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-014.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-014.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-015.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-015.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-016.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-016.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-017.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-017.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-018.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-018.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-019.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-019.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-020.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-style-tbrl-020.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-tbrl-001.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-tbrl-001.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-tbrl-002.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-tbrl-002.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-tbrl-003.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-tbrl-003.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-tbrl-004.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-tbrl-004.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-tbrl-005.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-tbrl-005.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-tbrl-006.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-tbrl-006.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-tbrl-007.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-tbrl-007.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-tbrl-008.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-tbrl-008.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-tbrl-009.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-tbrl-009.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-tbrl-010.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-tbrl-010.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-tbrl-011.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-tbrl-011.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-tbrl-012.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-tbrl-012.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-tbrl-014.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-tbrl-014.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-tbrl-015.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-tbrl-015.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-tbrl-016.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-tbrl-016.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-tbrl-017.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-tbrl-017.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-tbrl-018.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-tbrl-018.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-tbrl-019.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-tbrl-019.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>

--- a/css-text-decor/emphasis-marks/text-emphasis-tbrl-020.html
+++ b/css-text-decor/emphasis-marks/text-emphasis-tbrl-020.html
@@ -14,7 +14,6 @@
 	border-radius: 5px;
 	line-height: 1.5;
 	}
-:lang(mn) { font-family: "Mongolian Baiti", "Noto sans Mongolian", serif; }
 </style>
 <!-- the test -->
 <style>


### PR DESCRIPTION
Since they're not used in these tests.