### PR TITLE
shaping, Educational rewrite

### DIFF
--- a/batches/css-text-shaping.json
+++ b/batches/css-text-shaping.json
@@ -1,80 +1,80 @@
 tests = []
-tests[0]=["shaping-000.html","shaping: span","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping should not be broken across inline box boundaries with no styling change."] 
+tests[0]=["shaping-000.html","shaping: span","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping is not broken across inline box boundaries with no styling change."] 
 
-tests[1]=["shaping-015.html","shaping: text-decoration","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping should not be broken across inline box boundaries for changes in text-decoration."] 
+tests[1]=["shaping-015.html","shaping: text-decoration","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping is not broken across inline box boundaries for changes in text-decoration."] 
 
-tests[2]=["shaping-016.html","shaping: outline","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping should not be broken across inline box boundaries for changes in outline."] 
+tests[2]=["shaping-016.html","shaping: outline","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping is not broken across inline box boundaries for changes in outline."] 
 
-tests[3]=["shaping-007.html","shaping: font size 100%","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping should not be broken across inline box boundaries when font-size is set to 100%."] 
+tests[3]=["shaping-007.html","shaping: font size 100%","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping is not broken across inline box boundaries when font-size is set to 100%."] 
 
-tests[4]=["shaping-004.html","shaping: margin 0","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping should not be broken across inline box boundaries when margin is set to 0."] 
+tests[4]=["shaping-004.html","shaping: margin 0","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping is not broken across inline box boundaries when margin is set to 0."] 
 
-tests[5]=["shaping-005.html","shaping: padding 0","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping should not be broken across inline box boundaries when padding is set to 0."] 
+tests[5]=["shaping-005.html","shaping: padding 0","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping is not broken across inline box boundaries when padding is set to 0."] 
 
-tests[6]=["shaping-006.html","shaping: border 0","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping should not be broken across inline box boundaries when border is set to 0."] 
+tests[6]=["shaping-006.html","shaping: border 0","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping is not broken across inline box boundaries when border is set to 0."] 
 
-tests[7]=["shaping-001.html","shaping: colour","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping should not be broken across inline box boundaries for changes to colour."] 
+tests[7]=["shaping-001.html","shaping: colour","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping is not broken across inline box boundaries for changes to colour."] 
 
-tests[8]=["shaping-002.html","shaping: font-weight","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping should not be broken across inline box boundaries for changes in font weight."] 
+tests[8]=["shaping-002.html","shaping: font-weight","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping is not broken across inline box boundaries for changes in font weight."] 
 
-tests[9]=["shaping-003.html","shaping: font-style","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping should not be broken across inline box boundaries for changes in font style."] 
+tests[9]=["shaping-003.html","shaping: font-style","","","Shaping is not broken across inline box boundaries for changes in font style."] 
 
-tests[10]=["shaping-008.html","shaping: font size 120%","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping should not be broken across inline box boundaries for changes to font-size."] 
+tests[10]=["shaping-008.html","shaping: font size 120%","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping is not broken across inline box boundaries for changes to font-size."] 
 
-tests[11]=["shaping-017.html","shaping: em element","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping should not be broken across inline box boundaries for the em element."] 
+tests[11]=["shaping-017.html","shaping: em element","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping is not broken across inline box boundaries for the em element."] 
 
-tests[12]=["shaping-018.html","shaping: b element","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping should not be broken across inline box boundaries for the b element."] 
+tests[12]=["shaping-018.html","shaping: b element","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping is not broken across inline box boundaries for the b element."] 
 
-tests[13]=["shaping-009.html","shaping: margin &amp;gt; 0","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping SHOULD be broken across inline box boundaries when marginis set to a non-zero value."] 
+tests[13]=["shaping-009.html","shaping: margin &gt; 0","","","Shaping IS broken across inline box boundaries when margin is set to a non-zero value."] 
 
-tests[14]=["shaping-010.html","shaping: padding &amp;gt; 0","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping SHOULD be broken across inline box boundaries when padding is set to a non-zero value."] 
+tests[14]=["shaping-010.html","shaping: padding &gt; 0","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping IS broken across inline box boundaries when padding is set to a non-zero value."] 
 
-tests[15]=["shaping-011.html","shaping: border &amp;gt; 0","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping SHOULD be broken across inline box boundaries when border is set to a non-zero value."] 
+tests[15]=["shaping-011.html","shaping: border &gt; 0","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping IS broken across inline box boundaries when border is set to a non-zero value."] 
 
-tests[16]=["shaping-012.html","shaping: isolation","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping SHOULD be broken across inline box boundaries when isolation occurs."] 
+tests[16]=["shaping-012.html","shaping: isolation, bdi","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping IS broken across inline box boundaries when isolation occurs."] 
 
-tests[17]=["shaping-020.html","n&#039;ko, colour","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping should not be broken across inline box boundaries for changes to colour in N&#039;Ko."] 
+tests[17]=["shaping-020.html","n'ko, colour","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping is not broken across inline box boundaries for changes to colour in N'Ko."] 
 
-tests[18]=["shaping-021.html","n&#039;ko, font-style","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping should not be broken across inline box boundaries for changes to font-style in N&#039;Ko."] 
+tests[18]=["shaping-021.html","n'ko, font-style","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping is not broken across inline box boundaries for changes to font-style in N'Ko."] 
 
-tests[19]=["shaping-022.html","n&#039;ko, text-decoration","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping should not be broken across inline box boundaries for changes to text-decoration in N&#039;Ko."] 
+tests[19]=["shaping-022.html","n'ko, text-decoration","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping is not broken across inline box boundaries for changes to text-decoration in N'Ko."] 
 
-tests[20]=["shaping-023.html","mongolian, colour","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping should not be broken across inline box boundaries for changes to colour in Mongolian."] 
+tests[20]=["shaping-023.html","mongolian, colour","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping is not broken across inline box boundaries for changes to colour in Mongolian."] 
 
-tests[21]=["shaping-024.html","mongolian, font-style","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping should not be broken across inline box boundaries for changes to font-style in Mongolian."] 
+tests[21]=["shaping-024.html","mongolian, font-style","","","Shaping is not broken across inline box boundaries for changes to font-style in Mongolian."] 
 
-tests[22]=["shaping-025.html","mongolian, text-decoration","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping should not be broken across inline box boundaries for changes to text-decoration in Mongolian."] 
+tests[22]=["shaping-025.html","mongolian, text-decoration","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping is not broken across inline box boundaries for changes to text-decoration in Mongolian."] 
 
-tests[23]=["shaping_cchar-000.html","marked up diacritic: span","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping should not be broken by a span with no styling change for an intervening diacritic."] 
+tests[23]=["shaping_cchar-000.html","marked up diacritic: span","",'https://drafts.csswg.org/css-text/#boundary-shaping',"[exploratory] Shaping is not broken by a span (with no styling) around a diacritic."] 
 
-tests[24]=["shaping_cchar-001.html","styled diacritic: colour","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping should not be broken for changes to colour for an intervening diacritic."] 
+tests[24]=["shaping_cchar-001.html","styled diacritic: colour","",'https://drafts.csswg.org/css-text/#boundary-shaping',"[exploratory] Shaping is not broken when changes to colour are applied to an intervening diacritic."] 
 
-tests[25]=["shaping_cchar-002.html","styled diacritic: font-weight","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping should not be broken for changes in font weight for an intervening diacritic."] 
+tests[25]=["shaping_cchar-002.html","styled diacritic: font-weight","",'https://drafts.csswg.org/css-text/#boundary-shaping',"[exploratory] Shaping is not broken when changes to font weight are applied to an intervening diacritic."] 
 
-tests[26]=["shaping_cchar-003.html","styled diacritic: font-style","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping should not be broken for changes in font style for an intervening diacritic."] 
+tests[26]=["shaping_cchar-003.html","styled diacritic: font-style","",'https://drafts.csswg.org/css-text/#boundary-shaping',"[exploratory] Shaping is not broken when changes to font style are applied to an intervening diacritic."] 
 
-tests[27]=["shaping_cchar-004.html","styled diacritic: margin 0","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping should not be broken when margin is set to 0 for an intervening diacritic."] 
+tests[27]=["shaping_cchar-004.html","styled diacritic: margin 0","",'https://drafts.csswg.org/css-text/#boundary-shaping',"[exploratory] Shaping is not broken when margin is set to 0 for an intervening diacritic."] 
 
-tests[28]=["shaping_cchar-005.html","styled diacritic: padding 0","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping should not be broken when padding is set to 0 for an intervening diacritic."] 
+tests[28]=["shaping_cchar-005.html","styled diacritic: padding 0","",'https://drafts.csswg.org/css-text/#boundary-shaping',"[exploratory] Shaping is not broken when padding is set to 0 for an intervening diacritic."] 
 
-tests[29]=["shaping_cchar-006.html","styled diacritic: border 0","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping should not be broken when border is set to 0 for an intervening diacritic."] 
+tests[29]=["shaping_cchar-006.html","styled diacritic: border 0","",'https://drafts.csswg.org/css-text/#boundary-shaping',"[exploratory] Shaping is not broken when border is set to 0 for an intervening diacritic."] 
 
-tests[30]=["shaping_cchar-007.html","styled diacritic: font size 100%","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping should not be broken when font-size is set to 100% for an intervening diacritic."] 
+tests[30]=["shaping_cchar-007.html","styled diacritic: font size 100%","",'https://drafts.csswg.org/css-text/#boundary-shaping',"[exploratory] Shaping is not broken when font-size is set to 100% for an intervening diacritic."] 
 
-tests[31]=["shaping_cchar-008.html","styled diacritic: font size 120%","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping should not be broken when font-size is changed for an intervening diacritic."] 
+tests[31]=["shaping_cchar-008.html","styled diacritic: font size 120%","",'https://drafts.csswg.org/css-text/#boundary-shaping',"[exploratory] Shaping is not broken when changes to font-size are applied to an intervening diacritic."] 
 
-tests[32]=["shaping_cchar-009.html","styled diacritic: margin &amp;gt; 0","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping SHOULD be broken when margin is set to a non-zero value on an intervening diacritic."] 
+tests[32]=["shaping_cchar-009.html","styled diacritic: margin &gt; 0","",'https://drafts.csswg.org/css-text/#boundary-shaping',"[exploratory] Shaping IS BROKEN when margin is set to a non-zero value on an intervening diacritic."] 
 
-tests[33]=["shaping_cchar-010.html","styled diacritic: padding &amp;gt; 0","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping SHOULD be broken when padding is set to a non-zero value on an intervening diacritic."] 
+tests[33]=["shaping_cchar-010.html","styled diacritic: padding &gt; 0","",'https://drafts.csswg.org/css-text/#boundary-shaping',"[exploratory] Shaping IS BROKEN when padding is set to a non-zero value on an intervening diacritic."] 
 
-tests[34]=["shaping_cchar-011.html","styled diacritic: border &amp;gt; 0","",'https://drafts.csswg.org/css-text/#boundary-shaping',"Shaping SHOULD be broken when border is set to a non-zero value on an intervening diacritic."] 
+tests[34]=["shaping_cchar-011.html","styled diacritic: border &gt; 0","",'https://drafts.csswg.org/css-text/#boundary-shaping',"[exploratory] Shaping IS BROKEN when border is set to a non-zero value on an intervening diacritic."] 
 
-tests[35]=["shaping_lig-001.html","exploring ligatures: colour","",'https://drafts.csswg.org/css-text/#boundary-shaping',"[exploratory] Styling part of a ligature for colour will break joining behaviour across inline box boundaries, or apply the styling to the whole ligature."] 
+tests[35]=["shaping_lig-001.html","exploring ligatures: colour","",'https://drafts.csswg.org/css-text/#boundary-shaping',"[exploratory] Styling part of a ligature for colour will break joining behaviour across inline box boundaries, or apply the styling to the glyph corresponding to the middle letter, or apply the styling to the whole ligature."] 
 
-tests[36]=["shaping_lig-002.html","exploring ligatures: font-weight","",'https://drafts.csswg.org/css-text/#boundary-shaping',"[exploratory] Styling part of a ligature for font-weight will break joining behaviour across inline box boundaries, or apply the styling to the whole ligature."] 
+tests[36]=["shaping_lig-002.html","exploring ligatures: font-weight","",'https://drafts.csswg.org/css-text/#boundary-shaping',"[exploratory] Styling part of a ligature for font-weight will break joining behaviour across inline box boundaries, or apply the styling to the glyph corresponding to the middle letter, or apply the styling to the whole ligature."] 
 
-tests[37]=["shaping_lig-003.html","exploring ligatures: font-style","",'https://drafts.csswg.org/css-text/#boundary-shaping',"[exploratory] Styling part of a ligature for font-style will break joining behaviour across inline box boundaries, or apply the styling to the whole ligature."] 
+tests[37]=["shaping_lig-003.html","exploring ligatures: font-style","",'https://drafts.csswg.org/css-text/#boundary-shaping',"[exploratory] Styling part of a ligature for font-style will break joining behaviour across inline box boundaries, or apply the styling to the glyph corresponding to the middle letter, or apply the styling to the whole ligature."] 
 
-tests[38]=["shaping_lig-008.html","exploring ligatures: font size 120%","",'https://drafts.csswg.org/css-text/#boundary-shaping',"[exploratory] Styling part of a ligature with font-size changes will break joining behaviour across inline box boundaries, or apply the styling to the whole ligature."] 
+tests[38]=["shaping_lig-008.html","exploring ligatures: font size 120%","",'https://drafts.csswg.org/css-text/#boundary-shaping',"[exploratory] Styling part of a ligature for font-size will break joining behaviour across inline box boundaries, or apply the styling to the glyph corresponding to the middle letter, or apply the styling to the whole ligature."] 
 
 tests[39]=['../../testend','','','','']

--- a/css-text/shaping/shaping-000.html
+++ b/css-text/shaping/shaping-000.html
@@ -3,27 +3,34 @@
 <head>
 <meta charset="utf-8">
 <title>shaping: span</title>
-<meta name="assert" content="Shaping should not be broken across inline box boundaries with no styling change.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="Shaping is not broken across inline box boundaries with no styling change.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping-000-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the three Arabic characters join.</p>
+<p class="instructions">Test passes if the three Arabic characters in each box join, making the two boxes identical.</p>
+
+
 <div class="test" lang="ar" dir="rtl">ع<span>ع</span>ع</div>
-<div class="ref" lang="ar" dir="rtl">ع&zwj;<span>&zwj;ع&zwj;</span>&zwj;ع</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+<div class="ref" lang="ar" dir="rtl">ععع</div>
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The middle character of the top box is surrounded by a span element. The lower box uses just characters to show the expected outcome.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping-001.html
+++ b/css-text/shaping/shaping-001.html
@@ -3,30 +3,36 @@
 <head>
 <meta charset="utf-8">
 <title>shaping: colour</title>
-<meta name="assert" content="Shaping should not be broken across inline box boundaries for changes to colour.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="Shaping is not broken across inline box boundaries for changes to colour.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping-001-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 .color { color:blue; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the three Arabic characters join.</p>
-<small>Skip if markup alone breaks the join (test shaping-000)</small>
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: <span lang="ar" dir="rtl">ع<span>ع</span>ع</span> <span lang="ar" dir="rtl">ععع</span>.</em><br>Test passes if the three Arabic characters join, making the two boxes identical.</p>
+
 
 <div class="test" lang="ar" dir="rtl">ع<span class="color">ع</span>ع</div>
 <div class="ref" lang="ar" dir="rtl">ع&zwj;<span class="color">&zwj;ع&zwj;</span>&zwj;ع</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The middle character of the top box is surrounded by a span element to which the CSS "color:blue" is applied. The lower box uses ZWJ between characters and markup to show the expected outcome.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping-002.html
+++ b/css-text/shaping/shaping-002.html
@@ -3,30 +3,36 @@
 <head>
 <meta charset="utf-8">
 <title>shaping: font-weight</title>
-<meta name="assert" content="Shaping should not be broken across inline box boundaries for changes in font weight.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="Shaping is not broken across inline box boundaries for changes in font weight.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping-002-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 .fontweight { font-weight: bold; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the three Arabic characters join.</p>
-<small>Skip if markup alone breaks the join (test shaping-000)</small>
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: <span lang="ar" dir="rtl">ع<span>ع</span>ع</span> <span lang="ar" dir="rtl">ععع</span>.</em><br>Test passes if the three Arabic characters join, making the two boxes identical.</p>
+
 
 <div class="test" lang="ar" dir="rtl">ع<span class="fontweight">ع</span>ع</div>
 <div class="ref" lang="ar" dir="rtl">ع&zwj;<span class="fontweight">&zwj;ع&zwj;</span>&zwj;ع</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The middle character of the top box is surrounded by a span element to which the CSS "font-weight: bold" is applied. The lower box uses ZWJ between characters and markup to show the expected outcome.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping-003.html
+++ b/css-text/shaping/shaping-003.html
@@ -3,30 +3,35 @@
 <head>
 <meta charset="utf-8">
 <title>shaping: font-style</title>
-<meta name="assert" content="Shaping should not be broken across inline box boundaries for changes in font style.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping-003-ref.html">
-<style type="text/css">
+<meta name="assert" id="assert" content="Shaping is not broken across inline box boundaries for changes in font style.">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 .fontstyle { font-style: italic; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the three Arabic characters join.</p>
-<small>Skip if markup alone breaks the join (test shaping-000)</small>
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: <span lang="ar" dir="rtl">ع<span>ع</span>ع</span> <span lang="ar" dir="rtl">ععع</span>.</em><br>Test passes if the three Arabic characters join, making the two boxes identical.</p>
+
 
 <div class="test" lang="ar" dir="rtl">ع<span class="fontstyle">ع</span>ع</div>
 <div class="ref" lang="ar" dir="rtl">ع&zwj;<span class="fontstyle">&zwj;ع&zwj;</span>&zwj;ع</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The middle character of the top box is surrounded by a span element to which the CSS "font-style: italic" is applied. The lower box uses ZWJ between characters and markup to show the expected outcome.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping-004.html
+++ b/css-text/shaping/shaping-004.html
@@ -3,30 +3,36 @@
 <head>
 <meta charset="utf-8">
 <title>shaping: margin 0</title>
-<meta name="assert" content="Shaping should not be broken across inline box boundaries when margin is set to 0.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="Shaping is not broken across inline box boundaries when margin is set to 0.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping-004-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 .margin { margin:0; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the three Arabic characters join.</p>
-<small>Skip if markup alone breaks the join (test shaping-000)</small>
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: <span lang="ar" dir="rtl">ع<span>ع</span>ع</span> <span lang="ar" dir="rtl">ععع</span>.</em><br>Test passes if the three Arabic characters join, making the two boxes identical.</p>
+
 
 <div class="test" lang="ar" dir="rtl">ع<span class="margin">ع</span>ع</div>
 <div class="ref" lang="ar" dir="rtl">ع&zwj;<span class="margin">&zwj;ع&zwj;</span>&zwj;ع</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The middle character of the top box is surrounded by a span element to which the CSS "margin:0" is applied. The lower box uses ZWJ between characters and markup to show the expected outcome.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping-005.html
+++ b/css-text/shaping/shaping-005.html
@@ -3,30 +3,36 @@
 <head>
 <meta charset="utf-8">
 <title>shaping: padding 0</title>
-<meta name="assert" content="Shaping should not be broken across inline box boundaries when padding is set to 0.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="Shaping is not broken across inline box boundaries when padding is set to 0.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping-005-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 .padding { padding:0; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the three Arabic characters join.</p>
-<small>Skip if markup alone breaks the join (test shaping-000)</small>
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: <span lang="ar" dir="rtl">ع<span>ع</span>ع</span> <span lang="ar" dir="rtl">ععع</span>.</em><br>Test passes if the three Arabic characters join, making the two boxes identical.</p>
+
 
 <div class="test" lang="ar" dir="rtl">ع<span class="padding">ع</span>ع</div>
 <div class="ref" lang="ar" dir="rtl">ع&zwj;<span class="padding">&zwj;ع&zwj;</span>&zwj;ع</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The middle character of the top box is surrounded by a span element to which the CSS "padding:0" is applied. The lower box uses ZWJ between characters and markup to show the expected outcome.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping-006.html
+++ b/css-text/shaping/shaping-006.html
@@ -3,32 +3,36 @@
 <head>
 <meta charset="utf-8">
 <title>shaping: border 0</title>
-<meta name="assert" content="Shaping should not be broken across inline box boundaries when border is set to 0.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="Shaping is not broken across inline box boundaries when border is set to 0.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping-006-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
-.margin { margin:0; }
-.padding { padding:0; }
+
 .border { border:0; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the three Arabic characters join.</p>
-<small>Skip if markup alone breaks the join (test shaping-000)</small>
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: <span lang="ar" dir="rtl">ع<span>ع</span>ع</span> <span lang="ar" dir="rtl">ععع</span>.</em><br>Test passes if the three Arabic characters join, making the two boxes identical.</p>
+
 
 <div class="test" lang="ar" dir="rtl">ع<span class="border">ع</span>ع</div>
 <div class="ref" lang="ar" dir="rtl">ع&zwj;<span class="border">&zwj;ع&zwj;</span>&zwj;ع</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The middle character of the top box is surrounded by a span element to which the CSS "border:0" is applied. The lower box uses ZWJ between characters and markup to show the expected outcome.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping-007.html
+++ b/css-text/shaping/shaping-007.html
@@ -3,30 +3,36 @@
 <head>
 <meta charset="utf-8">
 <title>shaping: font size 100%</title>
-<meta name="assert" content="Shaping should not be broken across inline box boundaries when font-size is set to 100%.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="Shaping is not broken across inline box boundaries when font-size is set to 100%.">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping-007-ref.html">
-<style type="text/css">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 .fontsize { font-size:100%; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the three Arabic characters join.</p>
-<small>Skip if markup alone breaks the join (test shaping-000)</small>
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: <span lang="ar" dir="rtl">ع<span>ع</span>ع</span> <span lang="ar" dir="rtl">ععع</span>.</em><br>Test passes if the three Arabic characters join, making the two boxes identical.</p>
+
 
 <div class="test" lang="ar" dir="rtl">ع<span class="fontsize">ع</span>ع</div>
 <div class="ref" lang="ar" dir="rtl">ع&zwj;<span class="fontsize">&zwj;ع&zwj;</span>&zwj;ع</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The middle character of the top box is surrounded by a span element to which the CSS "font-size:100%" is applied. The lower box uses ZWJ between characters and markup to show the expected outcome.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping-008.html
+++ b/css-text/shaping/shaping-008.html
@@ -3,30 +3,36 @@
 <head>
 <meta charset="utf-8">
 <title>shaping: font size 120%</title>
-<meta name="assert" content="Shaping should not be broken across inline box boundaries for changes to font-size.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="Shaping is not broken across inline box boundaries for changes to font-size.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping-008-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 .fontsizeplus { font-size:120%; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the three Arabic characters join.</p>
-<small>Skip if markup alone breaks the join (test shaping-000)</small>
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: <span lang="ar" dir="rtl">ع<span>ع</span>ع</span> <span lang="ar" dir="rtl">ععع</span>.</em><br>Test passes if the three Arabic characters join, making the two boxes identical.</p>
+
 
 <div class="test" lang="ar" dir="rtl">ع<span class="fontsizeplus">ع</span>ع</div>
 <div class="ref" lang="ar" dir="rtl">ع&zwj;<span class="fontsizeplus">&zwj;ع&zwj;</span>&zwj;ع</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The middle character of the top box is surrounded by a span element to which the CSS "font-size:120%" is applied. The lower box uses ZWJ between characters and markup to show the expected outcome.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping-009.html
+++ b/css-text/shaping/shaping-009.html
@@ -3,29 +3,35 @@
 <head>
 <meta charset="utf-8">
 <title>shaping: margin &gt; 0</title>
-<meta name="assert" content="Shaping SHOULD be broken across inline box boundaries when marginis set to a non-zero value.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping-009-ref.html">
-<style type="text/css">
+<meta name="assert" id="assert" content="Shaping IS broken across inline box boundaries when margin is set to a non-zero value.">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 .margin { margin: 0.5em; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the three Arabic characters DON'T join.</p>
-<small>Skip if markup alone breaks the join (test shaping-000)</small>
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: <span lang="ar" dir="rtl">ع<span>ع</span>ع</span> <span lang="ar" dir="rtl">ععع</span>.</em><br>Test passes if the three Arabic characters DON'T join, making the two boxes identical.</p>
+
+
 <div class="test" lang="ar" dir="rtl">ع<span class="margin">ع</span>ع</div>
 <div class="ref" lang="ar" dir="rtl">ع&zwnj;<span class="margin">&zwnj;ع&zwnj;</span>&zwnj;ع</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The middle character of the top box is surrounded by a span element to which the CSS "margin: 0.5em" is applied. The lower box uses ZWNJ between characters and markup to show the expected outcome.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping-010.html
+++ b/css-text/shaping/shaping-010.html
@@ -3,29 +3,36 @@
 <head>
 <meta charset="utf-8">
 <title>shaping: padding &gt; 0</title>
-<meta name="assert" content="Shaping SHOULD be broken across inline box boundaries when padding is set to a non-zero value.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="Shaping IS broken across inline box boundaries when padding is set to a non-zero value.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping-010-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 .padding { padding: 0.5em; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the three Arabic characters DON'T join.</p>
-<small>Skip if markup alone breaks the join (test shaping-000)</small>
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: <span lang="ar" dir="rtl">ع<span>ع</span>ع</span> <span lang="ar" dir="rtl">ععع</span>.</em><br>Test passes if the three Arabic characters DON'T join, making the two boxes identical.</p>
+
+
 <div class="test" lang="ar" dir="rtl">ع<span class="padding">ع</span>ع</div>
 <div class="ref" lang="ar" dir="rtl">ع&zwnj;<span class="padding">&zwnj;ع&zwnj;</span>&zwnj;ع</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The middle character of the top box is surrounded by a span element to which the CSS "padding: 0.5em" is applied. The lower box uses ZNWJ between characters and markup to show the expected outcome.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping-011.html
+++ b/css-text/shaping/shaping-011.html
@@ -3,29 +3,36 @@
 <head>
 <meta charset="utf-8">
 <title>shaping: border &gt; 0</title>
-<meta name="assert" content="Shaping SHOULD be broken across inline box boundaries when border is set to a non-zero value.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="Shaping IS broken across inline box boundaries when border is set to a non-zero value.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping-011-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 .border { border: 1px solid #ccc; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the three Arabic characters DON'T join.</p>
-<small>Skip if markup alone breaks the join (test shaping-000)</small>
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: <span lang="ar" dir="rtl">ع<span>ع</span>ع</span> <span lang="ar" dir="rtl">ععع</span>.</em><br>Test passes if the three Arabic characters DON'T join, making the two boxes identical.</p>
+
+
 <div class="test" lang="ar" dir="rtl">ع<span class="border">ع</span>ع</div>
 <div class="ref" lang="ar" dir="rtl">ع&zwnj;<span class="border">&zwnj;ع&zwnj;</span>&zwnj;ع</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The middle character of the top box is surrounded by a span element to which the CSS "border: 1px solid #ccc" is applied. The lower box uses ZNWJ between characters and markup to show the expected outcome.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping-012.html
+++ b/css-text/shaping/shaping-012.html
@@ -3,30 +3,36 @@
 <head>
 <meta charset="utf-8">
 <title>shaping: isolation, bdi</title>
-<meta name="assert" content="Shaping SHOULD be broken across inline box boundaries when isolation occurs.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="Shaping IS broken across inline box boundaries when isolation occurs.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping-012-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the three Arabic characters DON'T join.</p>
-<p><small>Skip if markup alone breaks the join (test shaping-000)</small><br/>
-<small>Skip this test if bdi and dir=auto don't produce isolation in this browser.</small></p>
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: <span lang="ar" dir="rtl">ع<span>ع</span>ع</span> <span lang="ar" dir="rtl">ععع</span>.</em><br><em>Skip if the number 2 here appears to the left of the Arabic word: <bdi lang="ar" dir="rtl">اثنان</bdi> 2.</em><br>Test passes if the three Arabic characters DON'T join, making the two boxes identical.</p>
+
+
 <div class="test" lang="ar" dir="rtl">ع<bdi>ع</bdi>ع</div>
-<div class="ref" lang="ar" dir="rtl">ع&zwnj;<bdi>&zwnj;ع&zwnj;</bdi>&zwnj;ع</div>
-<!-- Notes:
-This test only works if bdi and dir=auto are supported by the browser.
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+<div class="ref" lang="ar" dir="rtl">ع&zwnj;ع&zwnj;ع</div>
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The middle character of the top box is surrounded by a bdi element. The lower box uses ZWNJ between characters and markup to show the expected outcome.</li>
+<li>The first 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>This test only works if the bdi tag produces isolation in this browser. The 'skip' directive with the number tests that.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping-013.html
+++ b/css-text/shaping/shaping-013.html
@@ -3,30 +3,37 @@
 <head>
 <meta charset="utf-8">
 <title>shaping: isolation, auto</title>
-<meta name="assert" content="Shaping SHOULD be broken across inline box boundaries when isolation occurs.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="Shaping IS broken across inline box boundaries when isolation occurs.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping-012-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the three Arabic characters DON'T join.</p>
-<p><small>Skip if markup alone breaks the join (test shaping-000)</small><br/>
-<small>Skip this test if bdi and dir=auto don't produce isolation in this browser.</small></p>
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: <span lang="ar" dir="rtl">ع<span>ع</span>ع</span> <span lang="ar" dir="rtl">ععع</span>.</em><br><em>Skip if the number 2 here appears to the left of the Arabic word: <span lang="ar" dir="auto">اثنان</span> 2.</em><br>Test passes if the three Arabic characters DON'T join, making the two boxes identical.</p>
+
+
 <div class="test" lang="ar" dir="rtl">ع<span dir="auto">ع</span>ع</div>
-<div class="ref" lang="ar" dir="rtl">ع&zwnj;<bdi>&zwnj;ع&zwnj;</bdi>&zwnj;ع</div>
-<!-- Notes:
-This test only works if bdi and dir=auto are supported by the browser.
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+<div class="ref" lang="ar" dir="rtl">ع&zwnj;ع&zwnj;ع</div>
+
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The middle character of the top box is surrounded by a span element with the attribute dir set to auto. The lower box uses ZWNJ between characters and markup to show the expected outcome.</li>
+<li>The first 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>This test only works if the dir=auto attribute produces isolation in this browser. The 'skip' directive with the number tests that.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping-015.html
+++ b/css-text/shaping/shaping-015.html
@@ -3,29 +3,36 @@
 <head>
 <meta charset="utf-8">
 <title>shaping: text-decoration</title>
-<meta name="assert" content="Shaping should not be broken across inline box boundaries for changes in text-decoration.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="Shaping is not broken across inline box boundaries for changes in text-decoration.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping-015-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 .styled { text-decoration: underline; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the three Arabic characters join.</p>
-<small>Skip if markup alone breaks the join (test shaping-000)</small>
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: <span lang="ar" dir="rtl">ع<span>ع</span>ع</span> <span lang="ar" dir="rtl">ععع</span>.</em><br>Test passes if the three Arabic characters join, making the two boxes identical.</p>
+
+
 <div class="test" lang="ar" dir="rtl">ع<span class="styled">ع</span>ع</div>
 <div class="ref" lang="ar" dir="rtl">ع&zwj;<span class="styled">&zwj;ع&zwj;</span>&zwj;ع</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The middle character of the top box is surrounded by a span element to which the CSS "text-decoration:underline" is applied. The lower box uses ZWJ between characters and markup to show the expected outcome.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping-016.html
+++ b/css-text/shaping/shaping-016.html
@@ -3,29 +3,36 @@
 <head>
 <meta charset="utf-8">
 <title>shaping: outline</title>
-<meta name="assert" content="Shaping should not be broken across inline box boundaries for changes in outline.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="Shaping is not broken across inline box boundaries for changes in outline.">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping-016-ref.html">
-<style type="text/css">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 .styled { outline: 1px solid blue; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the three Arabic characters join.</p>
-<small>Skip if markup alone breaks the join (test shaping-000)</small>
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: <span lang="ar" dir="rtl">ع<span>ع</span>ع</span> <span lang="ar" dir="rtl">ععع</span>.</em><br>Test passes if the three Arabic characters join, making the two boxes identical.</p>
+
+
 <div class="test" lang="ar" dir="rtl">ع<span class="styled">ع</span>ع</div>
 <div class="ref" lang="ar" dir="rtl">ع&zwj;<span class="styled">&zwj;ع&zwj;</span>&zwj;ع</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The middle character of the top box is surrounded by a span element to which the CSS "outline:1px solid blue" is applied. The lower box uses ZWJ between characters and markup to show the expected outcome.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping-017.html
+++ b/css-text/shaping/shaping-017.html
@@ -3,30 +3,35 @@
 <head>
 <meta charset="utf-8">
 <title>shaping: em element</title>
-<meta name="assert" content="Shaping should not be broken across inline box boundaries for the em element.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="Shaping is not broken across inline box boundaries for the em element.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping-017-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
-/* the CSS above is not part of the test */
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 .styled { font-style: italic; }
+/* the CSS above is not part of the test */
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if both boxes look the same.</p>
-<small>Skip if markup alone breaks the join (test shaping-000)</small>
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: <span lang="ar" dir="rtl">ع<span>ع</span>ع</span> <span lang="ar" dir="rtl">ععع</span>.</em><br>Test passes if the three Arabic characters join, making the two boxes identical.</p>
+
+
 <div class="test" lang="ar" dir="rtl">ع<em>ع</em>ع</div>
 <div class="ref" lang="ar" dir="rtl">ع&zwj;<span class="styled">&zwj;ع&zwj;</span>&zwj;ع</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
-It also assumes that the default rendering for the em element is italic.
--->
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The middle character of the top box is surrounded by an em element. The lower box uses ZWJ between characters and markup to show the expected outcome. The test assumes that the default rendering for the em element is italic.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping-018.html
+++ b/css-text/shaping/shaping-018.html
@@ -3,30 +3,37 @@
 <head>
 <meta charset="utf-8">
 <title>shaping: b element</title>
-<meta name="assert" content="Shaping should not be broken across inline box boundaries for the b element.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="Shaping is not broken across inline box boundaries for the b element.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping-018-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 .styled { font-weight: bold; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the three Arabic characters join.</p>
-<small>Skip if markup alone breaks the join (test shaping-000)</small>
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: <span lang="ar" dir="rtl">ع<span>ع</span>ع</span> <span lang="ar" dir="rtl">ععع</span>.</em><br>Test passes if the three Arabic characters join, making the two boxes identical.</p>
+
+
 <div class="test" lang="ar" dir="rtl">ع<b>ع</b>ع</div>
 <div class="ref" lang="ar" dir="rtl">ع&zwj;<span class="styled">&zwj;ع&zwj;</span>&zwj;ع</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
-It also assumes that the default rendering for the b element is bold.
--->
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The middle character of the top box is surrounded by a b element. The lower box uses ZWJ between characters and markup to show the expected outcome. The test assumes that the default rendering for the b element is bold.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
+</body>
 </body>
 </html>

--- a/css-text/shaping/shaping-020.html
+++ b/css-text/shaping/shaping-020.html
@@ -3,28 +3,37 @@
 <head>
 <meta charset="utf-8">
 <title>n'ko, colour</title>
-<meta name="assert" content="Shaping should not be broken across inline box boundaries for changes to colour in N'Ko.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="Shaping is not broken across inline box boundaries for changes to colour in N'Ko.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping-020-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoSansNko-regular-webfont.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
+:lang(nqo) { font-family: csstest_noto; }
 /* the CSS above is not part of the test */
+
 .styled { color:blue; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the three N'Ko characters join.</p>
-<div class="test" lang="nqo" dir="rtl">ߞ<span class="styled">ߞ</span>ߞ</div>
-<div class="ref" lang="nqo" dir="rtl">ߞ&zwj;<span class="styled">&zwj;ߞ&zwj;</span>&zwj;ߞ</div>
-<!-- Notes:
-This test uses the Noto Sans N'Ko font to control variables related to font choice.
--->
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: <span lang="nqo" dir="rtl">ߞ<span>ߞ</span>ߞ</span> <span lang="nqo" dir="rtl">ߞߞߞ</span>.</em><br>Test passes if the 5 N'Ko characters join, making the two boxes identical.</p>
+
+
+<div class="test" lang="nqo" dir="rtl">ߞߞ<span class="styled">ߞ</span>ߞߞ</div>
+<div class="ref" lang="nqo" dir="rtl">ߞߞ&zwj;<span class="styled">&zwj;ߞ&zwj;</span>&zwj;ߞߞ</div>
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The middle character of the top box is surrounded by a span element to which the CSS "color:blue" is applied. The lower box uses ZWJ between characters and markup to show the expected outcome.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Sans N'Ko webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping-021.html
+++ b/css-text/shaping/shaping-021.html
@@ -3,28 +3,38 @@
 <head>
 <meta charset="utf-8">
 <title>n'ko, font-style</title>
-<meta name="assert" content="Shaping should not be broken across inline box boundaries for changes to font-style in N'Ko.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="Shaping is not broken across inline box boundaries for changes to font-style in N'Ko.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping-021-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoSansNko-regular-webfont.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
+:lang(nqo) { font-family: csstest_noto; }
 /* the CSS above is not part of the test */
+
 .styled { font-style:italic; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the three N'Ko characters join.</p>
-<div class="test" lang="nqo" dir="rtl">ߞ<span class="styled">ߞ</span>ߞ</div>
-<div class="ref" lang="nqo" dir="rtl">ߞ&zwj;<span class="styled">&zwj;ߞ&zwj;</span>&zwj;ߞ</div>
-<!-- Notes:
-This test uses the Noto Sans N'Ko font to control variables related to font choice.
--->
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: <span lang="nqo" dir="rtl">ߞ<span>ߞ</span>ߞ</span> <span lang="nqo" dir="rtl">ߞߞߞ</span>.</em><br>Test passes if the 5 N'Ko characters join, making the two boxes identical.</p>
+
+
+
+<div class="test" lang="nqo" dir="rtl">ߞߞ<span class="styled">ߞ</span>ߞߞ</div>
+<div class="ref" lang="nqo" dir="rtl">ߞߞ&zwj;<span class="styled">&zwj;ߞ&zwj;</span>&zwj;ߞߞ</div>
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The middle character of the top box is surrounded by a span element to which the CSS "font-style:italic" is applied. The lower box uses ZWJ between characters and markup to show the expected outcome.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Sans N'Ko webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping-022.html
+++ b/css-text/shaping/shaping-022.html
@@ -3,28 +3,37 @@
 <head>
 <meta charset="utf-8">
 <title>n'ko, text-decoration</title>
-<meta name="assert" content="Shaping should not be broken across inline box boundaries for changes to text-decoration in N'Ko.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="Shaping is not broken across inline box boundaries for changes to text-decoration in N'Ko.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping-022-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoSansNko-regular-webfont.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
+:lang(nqo) { font-family: csstest_noto; }
 /* the CSS above is not part of the test */
+
 .styled { text-decoration: underline; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the three N'Ko characters join.</p>
-<div class="test" lang="nqo" dir="rtl">ߞ<span class="styled">ߞ</span>ߞ</div>
-<div class="ref" lang="nqo" dir="rtl">ߞ&zwj;<span class="styled">&zwj;ߞ&zwj;</span>&zwj;ߞ</div>
-<!-- Notes:
-This test uses the Noto Sans N'Ko font to control variables related to font choice.
--->
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: <span lang="nqo" dir="rtl">ߞ<span>ߞ</span>ߞ</span> <span lang="nqo" dir="rtl">ߞߞߞ</span>.</em><br>Test passes if the 5 N'Ko characters join, making the two boxes identical.</p>
+
+
+<div class="test" lang="nqo" dir="rtl">ߞߞ<span class="styled">ߞ</span>ߞߞ</div>
+<div class="ref" lang="nqo" dir="rtl">ߞߞ&zwj;<span class="styled">&zwj;ߞ&zwj;</span>&zwj;ߞߞ</div>
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The middle character of the top box is surrounded by a span element to which the CSS "text-decoration: underline" is applied. The lower box uses ZWJ between characters and markup to show the expected outcome.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Sans N'Ko webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping-023.html
+++ b/css-text/shaping/shaping-023.html
@@ -3,28 +3,38 @@
 <head>
 <meta charset="utf-8">
 <title>mongolian, colour</title>
-<meta name="assert" content="Shaping should not be broken across inline box boundaries for changes to colour in Mongolian.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="Shaping is not broken across inline box boundaries for changes to colour in Mongolian.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoSansMongolian-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; writing-mode: vertical-lr; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 2em; font-size: 110px; font-family: "csstest_noto"; writing-mode: vertical-lr; float: left; }
+:lang(mn) { font-family: csstest_noto; }
 /* the CSS above is not part of the test */
+
 .styled { color:blue; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the three Mongolian characters join in the right-hand line.</p>
-<small>Skip the test if the line on the left isn't arranged vertically and joined up.</small>
-<div class="test" lang="mn" dir="rtl">ᠨᠨᠨ<br/>ᠨ<span class="styled">ᠨ</span>ᠨ</div>
-<!-- Notes:
-This test uses the Noto Sans Mongolian font to control variables related to font choice.
-The test is manual because Safari (and possibly other browsers) don't support joining for vertical Mongolian anyway, so ref tests wouldn't test the correct thing.
--->
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: 1. <span lang="mn">ᠨᠨ<span>ᠨ</span>ᠨᠨ</span> 2. <span lang="mn">ᠨᠨᠨᠨᠨ</span>.</em><br><em>Skip if the text in the right-hand box is not joined up.</em><br>Test passes if the 3 Mongolian characters in each box join, making the two boxes identical.</p>
+
+
+<div class="test" lang="mn" dir="rtl">ᠨ<span class="styled">ᠨ</span>ᠨ</div>
+<div class="ref" lang="mn" dir="rtl">ᠨ&zwj;<span class="styled">&zwj;ᠨ&zwj;</span>&zwj;ᠨ</div>
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The middle character of the left-hand box is surrounded by a span element to which the CSS "color:blue" is applied. The right-hand box uses ZWJ between characters and markup to show the expected outcome.</li>
+<li>The first 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The second 'skip' test checks that the browser is capable of joining Mongolian characters in vertical alignment (Safari is not).</li>
+<li>The test uses a Noto Sans Mongolian webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping-024.html
+++ b/css-text/shaping/shaping-024.html
@@ -3,28 +3,37 @@
 <head>
 <meta charset="utf-8">
 <title>mongolian, font-style</title>
-<meta name="assert" content="Shaping should not be broken across inline box boundaries for changes to font-style in Mongolian.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
-<link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<style type="text/css">
+<meta name="assert" id="assert" content="Shaping is not broken across inline box boundaries for changes to font-style in Mongolian.">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoSansMongolian-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; writing-mode: vertical-lr; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 2em; font-size: 110px; font-family: "csstest_noto"; writing-mode: vertical-lr; float: left; }
+:lang(mn) { font-family: csstest_noto; }
 /* the CSS above is not part of the test */
+
 .styled { font-style:italic; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the three Mongolian characters join in the right-hand line.</p>
-<small>Skip the test if the line on the left isn't arranged vertically and joined up.</small>
-<div class="test" lang="mn" dir="rtl">ᠨᠨᠨ<br/>ᠨ<span class="styled">ᠨ</span>ᠨ</div>
-<!-- Notes:
-This test uses the Noto Sans Mongolian font to control variables related to font choice.
-The test is manual because Safari (and possibly other browsers) don't support joining for vertical Mongolian anyway, so ref tests wouldn't test the correct thing.
--->
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: 1. <span lang="mn">ᠨᠨ<span>ᠨ</span>ᠨᠨ</span> 2. <span lang="mn">ᠨᠨᠨᠨᠨ</span>.</em><br><em>Skip if the text in the right-hand box is not joined up.</em><br>Test passes if the 3 Mongolian characters in each box join, making the two boxes identical.</p>
+
+
+<div class="test" lang="mn" dir="rtl">ᠨ<span class="styled">ᠨ</span>ᠨ</div>
+<div class="ref" lang="mn" dir="rtl">ᠨ&zwj;<span class="styled">&zwj;ᠨ&zwj;</span>&zwj;ᠨ</div>
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The middle character of the left-hand box is surrounded by a span element to which the CSS "font-style:italic" is applied. The right-hand box uses ZWJ between characters and markup to show the expected outcome.</li>
+<li>The first 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The second 'skip' test checks that the browser is capable of joining Mongolian characters in vertical alignment (Safari is not).</li>
+<li>The test uses a Noto Sans Mongolian webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping-025.html
+++ b/css-text/shaping/shaping-025.html
@@ -3,28 +3,37 @@
 <head>
 <meta charset="utf-8">
 <title>mongolian, text-decoration</title>
-<meta name="assert" content="Shaping should not be broken across inline box boundaries for changes to text-decoration in Mongolian.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="Shaping is not broken across inline box boundaries for changes to text-decoration in Mongolian.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoSansMongolian-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; writing-mode: vertical-lr; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 2em; font-size: 110px; font-family: "csstest_noto"; writing-mode: vertical-lr; float: left; }
+:lang(mn) { font-family: csstest_noto; }
 /* the CSS above is not part of the test */
+
 .styled { text-decoration:underline; }
 </style>
 </head>
-<body>
-<p class="instructions">Test passes if the three Mongolian characters join in the right-hand line.</p>
-<small>Skip the test if the line on the left isn't arranged vertically and joined up.</small>
-<div class="test" lang="mn" dir="rtl">ᠨᠨᠨ<br/>ᠨ<span class="styled">ᠨ</span>ᠨ</div>
-<!-- Notes:
-This test uses the Noto Sans Mongolian font to control variables related to font choice.
-The test is manual because Safari (and possibly other browsers) don't support joining for vertical Mongolian anyway, so ref tests wouldn't test the correct thing.
--->
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: 1. <span lang="mn">ᠨᠨ<span>ᠨ</span>ᠨᠨ</span> 2. <span lang="mn">ᠨᠨᠨᠨᠨ</span>.</em><br><em>Skip if the text in the right-hand box is not joined up.</em><br>Test passes if the 3 Mongolian characters in each box join, making the two boxes identical.</p>
+
+
+<div class="test" lang="mn" dir="rtl">ᠨ<span class="styled">ᠨ</span>ᠨ</div>
+<div class="ref" lang="mn" dir="rtl">ᠨ&zwj;<span class="styled">&zwj;ᠨ&zwj;</span>&zwj;ᠨ</div>
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The middle character of the left-hand box is surrounded by a span element to which the CSS "text-decoration:underline" is applied. The right-hand box uses ZWJ between characters and markup to show the expected outcome.</li>
+<li>The first 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The second 'skip' test checks that the browser is capable of joining Mongolian characters in vertical alignment (Safari is not).</li>
+<li>The test uses a Noto Sans Mongolian webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping_cchar-000.html
+++ b/css-text/shaping/shaping_cchar-000.html
@@ -3,27 +3,34 @@
 <head>
 <meta charset="utf-8">
 <title>marked up diacritic: span</title>
-<meta name="assert" content="Shaping should not be broken by a span with no styling change for an intervening diacritic.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="[exploratory] Shaping is not broken by a span (with no styling) around a diacritic.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping_cchar-000-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the Arabic base characters in each word join.</p>
-<div class="test" lang="ar" dir="rtl">ع<span>&#x064E;</span>ع ع<span>&#x0651;</span>ع</div>
-<div class="ref" lang="ar" dir="rtl">ع&#x064E;ع ع&#x0651;ع</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+<p class="instructions">Test passes if all the Arabic base characters in the top box join, making the two boxes identical.</p>
+
+
+<div class="test" lang="ar" dir="rtl">ع<span>&#x064E;</span>عع<span>&#x0651;</span>ع</div>
+<div class="ref" lang="ar" dir="rtl">ع&#x064E;عع&#x0651;ع</div>
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The combining characters of the top box are surrounded by a span element. The lower box uses just characters to show the expected outcome.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping_cchar-001.html
+++ b/css-text/shaping/shaping_cchar-001.html
@@ -3,29 +3,36 @@
 <head>
 <meta charset="utf-8">
 <title>styled diacritic: colour</title>
-<meta name="assert" content="Shaping should not be broken for changes to colour for an intervening diacritic.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="[exploratory] Shaping is not broken when changes to colour are applied to an intervening diacritic.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping_cchar-001-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 .styled { color:blue; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the Arabic base characters in each word join.</p>
-<p><small>Skip if markup alone breaks the join (test shaping_cchar-000)</small></p>
-<div class="test" lang="ar" dir="rtl">ع<span class="styled">&#x064E;</span>ع ع<span class="styled">&#x0651;</span>ع</div>
-<div class="ref" lang="ar" dir="rtl">ع&zwj;<span class="styled">&zwj;&#x064E;&zwj;</span>&zwj;ع ع&zwj;<span class="styled">&zwj;&#x0651;&zwj;</span>&zwj;ع</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: (<span lang="ar" dir="rtl">ع<span>ع</span>ع</span>) (<span lang="ar" dir="rtl">ععع</span>).</em><br>Test passes if all the Arabic base characters in the top box join, making the base characters in the two boxes identical.</p>
+
+
+<div class="test" lang="ar" dir="rtl">ع<span class="styled">&#x064E;</span>عع<span class="styled">&#x0651;</span>ع</div>
+<div class="ref" lang="ar" dir="rtl">ع&zwj;<span class="styled">&zwj;&#x064E;&zwj;</span>&zwj;عع&zwj;<span class="styled">&zwj;&#x0651;&zwj;</span>&zwj;ع</div>
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The combining characters of the top box are surrounded by a span element which applies the CSS style "color:blue". The lower box uses ZWJ between characters and markup to show the expected outcome.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping_cchar-002.html
+++ b/css-text/shaping/shaping_cchar-002.html
@@ -3,29 +3,36 @@
 <head>
 <meta charset="utf-8">
 <title>styled diacritic: font-weight</title>
-<meta name="assert" content="Shaping should not be broken for changes in font weight for an intervening diacritic.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="[exploratory] Shaping is not broken when changes to font weight are applied to an intervening diacritic.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping_cchar-002-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 .styled { font-weight: bold; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the Arabic base characters in each word join.</p>
-<p><small>Skip if markup alone breaks the join (test shaping_cchar-000)</small><br/>
-<div class="test" lang="ar" dir="rtl">ع<span class="styled">&#x064E;</span>ع ع<span class="styled">&#x0651;</span>ع</div>
-<div class="ref" lang="ar" dir="rtl">ع&zwj;<span class="styled">&zwj;&#x064E;&zwj;</span>&zwj;ع ع&zwj;<span class="styled">&zwj;&#x0651;&zwj;</span>&zwj;ع</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: (<span lang="ar" dir="rtl">ع<span>ع</span>ع</span>) (<span lang="ar" dir="rtl">ععع</span>).</em><br>Test passes if all the Arabic base characters in the top box join, making the base characters in the two boxes identical.</p>
+
+
+<div class="test" lang="ar" dir="rtl">ع<span class="styled">&#x064E;</span>عع<span class="styled">&#x0651;</span>ع</div>
+<div class="ref" lang="ar" dir="rtl">ع&zwj;<span class="styled">&zwj;&#x064E;&zwj;</span>&zwj;عع&zwj;<span class="styled">&zwj;&#x0651;&zwj;</span>&zwj;ع</div>
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The combining characters of the top box are surrounded by a span element which applies the CSS style "font-weight: bold". The lower box uses ZWJ between characters and markup to show the expected outcome.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping_cchar-003.html
+++ b/css-text/shaping/shaping_cchar-003.html
@@ -3,29 +3,36 @@
 <head>
 <meta charset="utf-8">
 <title>styled diacritic: font-style</title>
-<meta name="assert" content="Shaping should not be broken for changes in font style for an intervening diacritic.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="[exploratory] Shaping is not broken when changes to font style are applied to an intervening diacritic.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping_cchar-003-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 .styled { font-style: italic; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the Arabic base characters in each word join.</p>
-<p><small>Skip if markup alone breaks the join (test shaping_cchar-000)</small><br/>
-<div class="test" lang="ar" dir="rtl">ع<span class="styled">&#x064E;</span>ع ع<span class="styled">&#x0651;</span>ع</div>
-<div class="ref" lang="ar" dir="rtl">ع&zwj;<span class="styled">&zwj;&#x064E;&zwj;</span>&zwj;ع ع&zwj;<span class="styled">&zwj;&#x0651;&zwj;</span>&zwj;ع</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: (<span lang="ar" dir="rtl">ع<span>ع</span>ع</span>) (<span lang="ar" dir="rtl">ععع</span>).</em><br>Test passes if all the Arabic base characters in the top box join, making the base characters in the two boxes identical.</p>
+
+
+<div class="test" lang="ar" dir="rtl">ع<span class="styled">&#x064E;</span>عع<span class="styled">&#x0651;</span>ع</div>
+<div class="ref" lang="ar" dir="rtl">ع&zwj;<span class="styled">&zwj;&#x064E;&zwj;</span>&zwj;عع&zwj;<span class="styled">&zwj;&#x0651;&zwj;</span>&zwj;ع</div>
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The combining characters of the top box are surrounded by a span element which applies the CSS style "font-style:italic". The lower box uses ZWJ between characters and markup to show the expected outcome.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping_cchar-004.html
+++ b/css-text/shaping/shaping_cchar-004.html
@@ -3,29 +3,36 @@
 <head>
 <meta charset="utf-8">
 <title>styled diacritic: margin 0</title>
-<meta name="assert" content="Shaping should not be broken when margin is set to 0 for an intervening diacritic.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="[exploratory] Shaping is not broken when margin is set to 0 for an intervening diacritic.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping_cchar-004-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 .styled { margin:0; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the Arabic base characters in each word join.</p>
-<p><small>Skip if markup alone breaks the join (test shaping_cchar-000)</small><br/>
-<div class="test" lang="ar" dir="rtl">ع<span class="styled">&#x064E;</span>ع ع<span class="styled">&#x0651;</span>ع</div>
-<div class="ref" lang="ar" dir="rtl">ع&zwj;<span class="styled">&zwj;&#x064E;&zwj;</span>&zwj;ع ع&zwj;<span class="styled">&zwj;&#x0651;&zwj;</span>&zwj;ع</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: (<span lang="ar" dir="rtl">ع<span>ع</span>ع</span>) (<span lang="ar" dir="rtl">ععع</span>).</em><br>Test passes if all the Arabic base characters in the top box join, making the base characters in the two boxes identical.</p>
+
+
+<div class="test" lang="ar" dir="rtl">ع<span class="styled">&#x064E;</span>عع<span class="styled">&#x0651;</span>ع</div>
+<div class="ref" lang="ar" dir="rtl">ع&zwj;<span class="styled">&zwj;&#x064E;&zwj;</span>&zwj;عع&zwj;<span class="styled">&zwj;&#x0651;&zwj;</span>&zwj;ع</div>
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The combining characters of the top box are surrounded by a span element which applies the CSS style "margin:0". The lower box uses ZWJ between characters and markup to show the expected outcome.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping_cchar-005.html
+++ b/css-text/shaping/shaping_cchar-005.html
@@ -3,29 +3,36 @@
 <head>
 <meta charset="utf-8">
 <title>styled diacritic: padding 0</title>
-<meta name="assert" content="Shaping should not be broken when padding is set to 0 for an intervening diacritic.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="[exploratory] Shaping is not broken when padding is set to 0 for an intervening diacritic.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping_cchar-005-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 .styled { padding:0; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the Arabic base characters in each word join.</p>
-<p><small>Skip if markup alone breaks the join (test shaping_cchar-000)</small><br/>
-<div class="test" lang="ar" dir="rtl">ع<span class="styled">&#x064E;</span>ع ع<span class="styled">&#x0651;</span>ع</div>
-<div class="ref" lang="ar" dir="rtl">ع&zwj;<span class="styled">&zwj;&#x064E;&zwj;</span>&zwj;ع ع&zwj;<span class="styled">&zwj;&#x0651;&zwj;</span>&zwj;ع</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: (<span lang="ar" dir="rtl">ع<span>ع</span>ع</span>) (<span lang="ar" dir="rtl">ععع</span>).</em><br>Test passes if all the Arabic base characters in the top box join, making the base characters in the two boxes identical.</p>
+
+
+<div class="test" lang="ar" dir="rtl">ع<span class="styled">&#x064E;</span>عع<span class="styled">&#x0651;</span>ع</div>
+<div class="ref" lang="ar" dir="rtl">ع&zwj;<span class="styled">&zwj;&#x064E;&zwj;</span>&zwj;عع&zwj;<span class="styled">&zwj;&#x0651;&zwj;</span>&zwj;ع</div>
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The combining characters of the top box are surrounded by a span element which applies the CSS style "padding:0". The lower box uses ZWJ between characters and markup to show the expected outcome.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping_cchar-006.html
+++ b/css-text/shaping/shaping_cchar-006.html
@@ -3,29 +3,36 @@
 <head>
 <meta charset="utf-8">
 <title>styled diacritic: border 0</title>
-<meta name="assert" content="Shaping should not be broken when border is set to 0 for an intervening diacritic.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="[exploratory] Shaping is not broken when border is set to 0 for an intervening diacritic.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping_cchar-006-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 .styled { border:0; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the Arabic base characters in each word join.</p>
-<p><small>Skip if markup alone breaks the join (test shaping_cchar-000)</small><br/>
-<div class="test" lang="ar" dir="rtl">ع<span class="styled">&#x064E;</span>ع ع<span class="styled">&#x0651;</span>ع</div>
-<div class="ref" lang="ar" dir="rtl">ع&zwj;<span class="styled">&zwj;&#x064E;&zwj;</span>&zwj;ع ع&zwj;<span class="styled">&zwj;&#x0651;&zwj;</span>&zwj;ع</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: (<span lang="ar" dir="rtl">ع<span>ع</span>ع</span>) (<span lang="ar" dir="rtl">ععع</span>).</em><br>Test passes if all the Arabic base characters in the top box join, making the base characters in the two boxes identical.</p>
+
+
+<div class="test" lang="ar" dir="rtl">ع<span class="styled">&#x064E;</span>عع<span class="styled">&#x0651;</span>ع</div>
+<div class="ref" lang="ar" dir="rtl">ع&zwj;<span class="styled">&zwj;&#x064E;&zwj;</span>&zwj;عع&zwj;<span class="styled">&zwj;&#x0651;&zwj;</span>&zwj;ع</div>
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The combining characters of the top box are surrounded by a span element which applies the CSS style "color:blue". The lower box uses ZWJ between characters and markup to show the expected outcome.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping_cchar-007.html
+++ b/css-text/shaping/shaping_cchar-007.html
@@ -3,29 +3,36 @@
 <head>
 <meta charset="utf-8">
 <title>styled diacritic: font size 100%</title>
-<meta name="assert" content="Shaping should not be broken when font-size is set to 100% for an intervening diacritic.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="[exploratory] Shaping is not broken when font-size is set to 100% for an intervening diacritic.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping_cchar-007-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 .styled { font-size:100%; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the Arabic base characters in each word join.</p>
-<p><small>Skip if markup alone breaks the join (test shaping_cchar-000)</small><br/>
-<div class="test" lang="ar" dir="rtl">ع<span class="styled">&#x064E;</span>ع ع<span class="styled">&#x0651;</span>ع</div>
-<div class="ref" lang="ar" dir="rtl">ع&zwj;<span class="styled">&zwj;&#x064E;&zwj;</span>&zwj;ع ع&zwj;<span class="styled">&zwj;&#x0651;&zwj;</span>&zwj;ع</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: (<span lang="ar" dir="rtl">ع<span>ع</span>ع</span>) (<span lang="ar" dir="rtl">ععع</span>).</em><br>Test passes if all the Arabic base characters in the top box join, making the base characters in the two boxes identical.</p>
+
+
+<div class="test" lang="ar" dir="rtl">ع<span class="styled">&#x064E;</span>عع<span class="styled">&#x0651;</span>ع</div>
+<div class="ref" lang="ar" dir="rtl">ع&zwj;<span class="styled">&zwj;&#x064E;&zwj;</span>&zwj;عع&zwj;<span class="styled">&zwj;&#x0651;&zwj;</span>&zwj;ع</div>
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The combining characters of the top box are surrounded by a span element which applies the CSS style "font-size:100%". The lower box uses ZWJ between characters and markup to show the expected outcome.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping_cchar-008.html
+++ b/css-text/shaping/shaping_cchar-008.html
@@ -3,29 +3,36 @@
 <head>
 <meta charset="utf-8">
 <title>styled diacritic: font size 120%</title>
-<meta name="assert" content="Shaping should not be broken when font-size is changed for an intervening diacritic.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="[exploratory] Shaping is not broken when changes to font-size are applied to an intervening diacritic.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping_cchar-008-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 .styled { font-size:120%; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the Arabic base characters in each word join.</p>
-<p><small>Skip if markup alone breaks the join (test shaping_cchar-000)</small><br/>
-<div class="test" lang="ar" dir="rtl">ع<span class="styled">&#x064E;</span>ع ع<span class="styled">&#x0651;</span>ع</div>
-<div class="ref" lang="ar" dir="rtl">ع&zwj;<span class="styled">&zwj;&#x064E;&zwj;</span>&zwj;ع ع&zwj;<span class="styled">&zwj;&#x0651;&zwj;</span>&zwj;ع</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: (<span lang="ar" dir="rtl">ع<span>ع</span>ع</span>) (<span lang="ar" dir="rtl">ععع</span>).</em><br>Test passes if all the Arabic base characters in the top box join, making the base characters in the two boxes identical.</p>
+
+
+<div class="test" lang="ar" dir="rtl">ع<span class="styled">&#x064E;</span>عع<span class="styled">&#x0651;</span>ع</div>
+<div class="ref" lang="ar" dir="rtl">ع&zwj;<span class="styled">&zwj;&#x064E;&zwj;</span>&zwj;عع&zwj;<span class="styled">&zwj;&#x0651;&zwj;</span>&zwj;ع</div>
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The combining characters of the top box are surrounded by a span element which applies the CSS style "font-size:120%". The lower box uses ZWJ between characters and markup to show the expected outcome.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping_cchar-009.html
+++ b/css-text/shaping/shaping_cchar-009.html
@@ -3,29 +3,36 @@
 <head>
 <meta charset="utf-8">
 <title>styled diacritic: margin &gt; 0</title>
-<meta name="assert" content="Shaping SHOULD be broken when margin is set to a non-zero value on an intervening diacritic.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="[exploratory] Shaping IS BROKEN when margin is set to a non-zero value on an intervening diacritic.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping_cchar-009-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 5em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 5em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 .styled { margin: 0.5em; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the Arabic characters DON'T show joining forms.</p>
-<p><small>Skip if markup alone breaks the join (test shaping_cchar-000)</small><br/>
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: (<span lang="ar" dir="rtl">ع<span>ع</span>ع</span>) (<span lang="ar" dir="rtl">ععع</span>).</em><br>Test passes if NONE of the Arabic base characters in the top box join, making the base characters in the two boxes identical.</p>
+
+
 <div class="test" lang="ar" dir="rtl">ع<span class="styled">&#x064E;</span>ع ع<span class="styled">&#x0651;</span>ع</div>
 <div class="ref" lang="ar" dir="rtl">ع&zwnj;<span class="styled">&zwnj;&#x064E;&zwnj;</span>&zwnj;ع ع&zwnj;<span class="styled">&zwnj;&#x0651;&zwnj;</span>&zwnj;ع</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The combining characters of the top box are surrounded by a span element which applies the CSS style "margin: 0.5em". The lower box uses ZWNJ between characters and markup to show the expected outcome.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping_cchar-010.html
+++ b/css-text/shaping/shaping_cchar-010.html
@@ -3,29 +3,36 @@
 <head>
 <meta charset="utf-8">
 <title>styled diacritic: padding &gt; 0</title>
-<meta name="assert" content="Shaping SHOULD be broken when padding is set to a non-zero value on an intervening diacritic.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="[exploratory] Shaping IS BROKEN when padding is set to a non-zero value on an intervening diacritic.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping_cchar-010-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 5em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 5em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 .styled { padding: 0.5em; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the Arabic characters DON'T show joining forms.</p>
-<p><small>Skip if markup alone breaks the join (test shaping_cchar-000)</small><br/>
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: (<span lang="ar" dir="rtl">ع<span>ع</span>ع</span>) (<span lang="ar" dir="rtl">ععع</span>).</em><br>Test passes if NONE of the Arabic base characters in the top box join, making the base characters in the two boxes identical.</p>
+
+
 <div class="test" lang="ar" dir="rtl">ع<span class="styled">&#x064E;</span>ع ع<span class="styled">&#x0651;</span>ع</div>
 <div class="ref" lang="ar" dir="rtl">ع&zwnj;<span class="styled">&zwnj;&#x064E;&zwnj;</span>&zwnj;ع ع&zwnj;<span class="styled">&zwnj;&#x0651;&zwnj;</span>&zwnj;ع</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The combining characters of the top box are surrounded by a span element which applies the CSS style "padding:0.5em". The lower box uses ZWNJ between characters and markup to show the expected outcome.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping_cchar-011.html
+++ b/css-text/shaping/shaping_cchar-011.html
@@ -3,29 +3,36 @@
 <head>
 <meta charset="utf-8">
 <title>styled diacritic: border &gt; 0</title>
-<meta name="assert" content="Shaping SHOULD be broken when border is set to a non-zero value on an intervening diacritic.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="[exploratory] Shaping IS BROKEN when border is set to a non-zero value on an intervening diacritic.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping_cchar-011-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 5em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 5em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 .styled { border: 1px solid #ccc; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the Arabic characters DON'T show joining forms.</p>
-<p><small>Skip if markup alone breaks the join (test shaping_cchar-000)</small><br/>
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: (<span lang="ar" dir="rtl">ع<span>ع</span>ع</span>) (<span lang="ar" dir="rtl">ععع</span>).</em><br>Test passes if NONE of the Arabic base characters in the top box join, making the base characters in the two boxes identical.</p>
+
+
 <div class="test" lang="ar" dir="rtl">ع<span class="styled">&#x064E;</span>ع ع<span class="styled">&#x0651;</span>ع</div>
 <div class="ref" lang="ar" dir="rtl">ع&zwnj;<span class="styled">&zwnj;&#x064E;&zwnj;</span>&zwnj;ع ع&zwnj;<span class="styled">&zwnj;&#x0651;&zwnj;</span>&zwnj;ع</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The combining characters of the top box are surrounded by a span element which applies the CSS style "margin: 0.5em". The lower box uses ZWNJ between characters and markup to show the expected outcome.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping_lig-000.html
+++ b/css-text/shaping/shaping_lig-000.html
@@ -3,27 +3,33 @@
 <head>
 <meta charset="utf-8">
 <title>ligatures: span</title>
-<meta name="assert" content="Markup inside a ligature with no styling will NOT break joining behaviour.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="[exploratory] Shaping is not broken by a span (with no styling) inside a ligature.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<link rel="match" href="reference/shaping_lig-000-ref.html">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the three Arabic characters join.</p>
+<p class="instructions">Test passes if all the Arabic characters in the top box join, making the two boxes identical.</p>
+
+
 <div class="test" lang="ar" dir="rtl">ع<span>ل</span>ا</div>
 <div class="ref" lang="ar" dir="rtl">علا</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The middle character of the top box is surrounded by a span element. The lower box uses just characters to show the expected outcome.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping_lig-001.html
+++ b/css-text/shaping/shaping_lig-001.html
@@ -3,27 +3,35 @@
 <head>
 <meta charset="utf-8">
 <title>exploring ligatures: colour</title>
-<meta name="assert" content="[exploratory] Styling part of a ligature for colour will break joining behaviour across inline box boundaries, or apply the styling to the glyph corresponding to the middle letter, or apply the styling to the whole ligature.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="[exploratory] Styling part of a ligature for colour will break joining behaviour across inline box boundaries, or apply the styling to the glyph corresponding to the middle letter, or apply the styling to the whole ligature.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 .styled { color:blue; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the three Arabic characters don't join, or styling is applied to the glyph corresponding to the middle letter, or the styling is applied to the whole ligature.</p>
-<small>Skip if markup alone breaks the join (test shaping-000)</small>
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: <span lang="ar" dir="rtl">ع<span>ع</span>ع</span> <span lang="ar" dir="rtl">ععع</span>.</em><br>Test passes if the three Arabic characters don't join, or styling is applied to the glyph corresponding to the middle letter, or the styling is applied to the whole ligature.</p>
+
+
 <div class="test" lang="ar" dir="rtl">ع<span class="styled">ل</span>ا</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The middle character in the box is surrounded by a span element to which the CSS style "color:blue" is applied.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping_lig-002.html
+++ b/css-text/shaping/shaping_lig-002.html
@@ -3,27 +3,35 @@
 <head>
 <meta charset="utf-8">
 <title>exploring ligatures: font-weight</title>
-<meta name="assert" content="[exploratory] Styling part of a ligature for font-weight will break joining behaviour across inline box boundaries, or apply the styling to the glyph corresponding to the middle letter, or apply the styling to the whole ligature.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="[exploratory] Styling part of a ligature for font-weight will break joining behaviour across inline box boundaries, or apply the styling to the glyph corresponding to the middle letter, or apply the styling to the whole ligature.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 .styled { font-weight: bold; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the three Arabic characters don't join, or styling is applied to the glyph corresponding to the middle letter, or the styling is applied to the whole ligature.</p>
-<small>Skip if markup alone breaks the join (test shaping-000)</small>
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: <span lang="ar" dir="rtl">ع<span>ع</span>ع</span> <span lang="ar" dir="rtl">ععع</span>.</em><br>Test passes if the three Arabic characters don't join, or styling is applied to the glyph corresponding to the middle letter, or the styling is applied to the whole ligature.</p>
+
+
 <div class="test" lang="ar" dir="rtl">ع<span class="styled">ل</span>ا</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The middle character in the box is surrounded by a span element to which the CSS style "font-weight: bold" is applied.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping_lig-003.html
+++ b/css-text/shaping/shaping_lig-003.html
@@ -3,27 +3,35 @@
 <head>
 <meta charset="utf-8">
 <title>exploring ligatures: font-style</title>
-<meta name="assert" content="[exploratory] Styling part of a ligature for font-style will break joining behaviour across inline box boundaries, or apply the styling to the glyph corresponding to the middle letter, or apply the styling to the whole ligature.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="[exploratory] Styling part of a ligature for font-style will break joining behaviour across inline box boundaries, or apply the styling to the glyph corresponding to the middle letter, or apply the styling to the whole ligature.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 .styled { font-style: italic; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the three Arabic characters don't join, or styling is applied to the glyph corresponding to the middle letter, or the styling is applied to the whole ligature.</p>
-<small>Skip if markup alone breaks the join (test shaping-000)</small>
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: <span lang="ar" dir="rtl">ع<span>ع</span>ع</span> <span lang="ar" dir="rtl">ععع</span>.</em><br>Test passes if the three Arabic characters don't join, or styling is applied to the glyph corresponding to the middle letter, or the styling is applied to the whole ligature.</p>
+
+
 <div class="test" lang="ar" dir="rtl">ع<span class="styled">ل</span>ا</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The middle character in the box is surrounded by a span element to which the CSS style "font-style: italic" is applied.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>

--- a/css-text/shaping/shaping_lig-008.html
+++ b/css-text/shaping/shaping_lig-008.html
@@ -3,27 +3,35 @@
 <head>
 <meta charset="utf-8">
 <title>exploring ligatures: font size 120%</title>
-<meta name="assert" content="[exploratory] Styling part of a ligature for font-size will break joining behaviour across inline box boundaries, or apply the styling to the glyph corresponding to the middle letter, or apply the styling to the whole ligature.">
-<link rel="author" title="Richard Ishida" href="mailto:ishida@w3.org">
+<meta name="assert" id="assert" content="[exploratory] Styling part of a ligature for font-size will break joining behaviour across inline box boundaries, or apply the styling to the glyph corresponding to the middle letter, or apply the styling to the whole ligature.">
 <link rel="help" href="https://drafts.csswg.org/css-text/#boundary-shaping">
-<style type="text/css">
+<link rel="author" title="r12a" href="mailto:r12a@w3.org">
+<link rel="stylesheet" href="../../fonts/metadata_styles.css"/>
+<style>
 @font-face {
     font-family: 'csstest_noto';
     src: url('../../fonts/noto/NotoNaskhArabic-regular.woff2') format('woff2');
-    font-weight: normal;
-    font-style: normal;
     }
-.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 120px; font-family: "csstest_noto"; }
+.test, .ref { border: 1px solid #02D7F6;  margin: 20px;  padding: 10px; width: 3em; font-size: 110px; font-family: "csstest_noto"; }
 /* the CSS above is not part of the test */
+
 .styled { font-size:120%; }
 </style>
 </head>
 <body>
-<p class="instructions">Test passes if the three Arabic characters don't join, or styling is applied to the glyph corresponding to the middle letter, or the styling is applied to the whole ligature.</p>
-<small>Skip if markup alone breaks the join (test shaping-000)</small>
+<p class="instructions"><em>Skip if the two sequences to the right have different shapes: <span lang="ar" dir="rtl">ع<span>ع</span>ع</span> <span lang="ar" dir="rtl">ععع</span>.</em><br>Test passes if the three Arabic characters don't join, or styling is applied to the glyph corresponding to the middle letter, or the styling is applied to the whole ligature.</p>
+
+
 <div class="test" lang="ar" dir="rtl">ع<span class="styled">ل</span>ا</div>
-<!-- Notes:
-This test uses the Noto Naskh Arabic font to control variables related to font choice.
--->
+
+
+<div id="info">
+<p id="assertion"></p><script>document.getElementById('assertion').textContent='Assertion: '+document.getElementById('assert').content</script>
+<ul class="notes">
+<li>The middle character in the box is surrounded by a span element to which the CSS style "font-size:120%" is applied.</li>
+<li>The 'skip' directive compares a sequence separated by unstyled span markup to one without. If the displayed results are different this test will always fail, regardless of the styling, and should be skipped.</li>
+<li>The test uses a Noto Naskh Arabic webfont to control variables related to font choice.</li>
+</ul>
+</div>
 </body>
 </html>


### PR DESCRIPTION
Rewrite incorporating Florian's comments at https://github.com/web-platform-tests/wpt/pull/16393 but also adding extra visible information per the policy to make i18n tests education-friendly, and additional changes to the tests, instructions and assertions.
Links to ref files removed, but the ref files are still in place at the moment.