### PR TITLE
Remove type="text" in textarea

### DIFF
--- a/exploratory/hyphenation/int-hyphens.html
+++ b/exploratory/hyphenation/int-hyphens.html
@@ -49,7 +49,7 @@ for (let i=0;i<tests.length;i++) tests[i].style.writingMode = value
 
 
 <!-- INPUT AREA -->
-<div><textarea id="assertion" type="text" placeholder="Add an assertion here." dir="auto"></textarea></div>
+<div><textarea id="assertion" placeholder="Add an assertion here." dir="auto"></textarea></div>
 
 <div><textarea id="in" dir="auto" type="text" placeholder="Add text to be tested text here and click on GO."></textarea> 
 <button onClick="setText(document.getElementById('in').value)" id="go" style="vertical-align: top;">Go</button></div>

--- a/exploratory/initials/int-first-letter.html
+++ b/exploratory/initials/int-first-letter.html
@@ -35,7 +35,7 @@ setText(document.getElementById('in').value)
 
 
 <!-- INPUT AREA -->
-<div><textarea id="assertion" type="text" placeholder="Add an assertion here." dir="auto"></textarea></div>
+<div><textarea id="assertion" placeholder="Add an assertion here." dir="auto"></textarea></div>
 <div><textarea id="in" type="text" placeholder="Add text to be tested text here and click on GO." style="vertical-align: top;" dir="auto"></textarea> 
 <button onClick="setText(document.getElementById('in').value)" id="go" style="vertical-align: top;">Go</button></div>
 

--- a/exploratory/initials/int-initial-letters.html
+++ b/exploratory/initials/int-initial-letters.html
@@ -51,7 +51,7 @@ setText(document.getElementById('in').value)
 
 
 <!-- INPUT AREA -->
-<div><textarea id="assertion" type="text" placeholder="Add an assertion here." dir="auto"></textarea></div>
+<div><textarea id="assertion" placeholder="Add an assertion here." dir="auto"></textarea></div>
 
 <div><textarea id="in" type="text" placeholder="Add text to be tested text here and click on GO." style="vertical-align: top;" dir="auto"></textarea> 
 <button onClick="setText(document.getElementById('in').value)" id="go" style="vertical-align: top;">Go</button></div>

--- a/exploratory/inline_notes/int-ruby.html
+++ b/exploratory/inline_notes/int-ruby.html
@@ -60,7 +60,7 @@ for (let i=0;i<tests.length;i++) { tests[i].style.writingMode = value }
 <h1>Interactive test: ruby</h1>
 
 <!-- INPUT AREA -->
-<div><textarea id="assertion" type="text" placeholder="Add an assertion here." dir="auto"></textarea></div>
+<div><textarea id="assertion" placeholder="Add an assertion here." dir="auto"></textarea></div>
 <div><textarea id="in" dir="auto" type="text" placeholder="Add text to be tested text here and click on GO."></textarea> 
 <button onClick="setText(document.getElementById('in').value)" id="go" style="vertical-align: top;">Go</button></div>
 

--- a/exploratory/justification/int-line-alignment.html
+++ b/exploratory/justification/int-line-alignment.html
@@ -84,7 +84,7 @@ for (let i=0;i<tests.length;i++) tests[i].style.writingMode = value
 
 
 <!-- INPUT AREA -->
-<div><textarea id="assertion" type="text" placeholder="Add an assertion here." dir="auto"></textarea></div>
+<div><textarea id="assertion" placeholder="Add an assertion here." dir="auto"></textarea></div>
 
 <div><textarea id="in" dir="auto" type="text" placeholder="Add text to be tested text here and click on GO."></textarea> 
 <button onClick="setText(document.getElementById('in').value)" id="go" style="vertical-align: top;">Go</button></div>

--- a/exploratory/justification/int-text-justify.html
+++ b/exploratory/justification/int-text-justify.html
@@ -43,7 +43,7 @@ for (let i=0;i<tests.length;i++) { tests[i].style.textAlignLast = value }
 
 
 <!-- INPUT AREA -->
-<div><textarea id="assertion" type="text" placeholder="Add an assertion here." dir="auto"></textarea></div>
+<div><textarea id="assertion" placeholder="Add an assertion here." dir="auto"></textarea></div>
 <div><textarea id="in" dir="auto" type="text" placeholder="Add text to be tested text here and click on GO."></textarea> 
 <button onClick="setText(document.getElementById('in').value)" id="go" style="vertical-align: top;">Go</button></div>
 

--- a/exploratory/line_breaking/int-line-break.html
+++ b/exploratory/line_breaking/int-line-break.html
@@ -36,7 +36,7 @@ for (let i=0;i<tests.length;i++) { tests[i].style.wordBreak = value }
 
 
 <!-- INPUT AREA -->
-<div><textarea id="assertion" type="text" placeholder="Add an assertion here." dir="auto"></textarea></div>
+<div><textarea id="assertion" placeholder="Add an assertion here." dir="auto"></textarea></div>
 <div><textarea id="in" type="text" placeholder="Add text to be tested text here and click on GO." dir="auto"></textarea> 
 <button onClick="setText(document.getElementById('in').value)" id="go" style="vertical-align: top;">Go</button></div>
 

--- a/exploratory/lists/int-lists.html
+++ b/exploratory/lists/int-lists.html
@@ -60,7 +60,7 @@ document.getElementById('uprightSettings').innerHTML = 'li::marker { text-combin
 
 
 <!-- INPUT AREA -->
-<div><textarea id="assertion" type="text" placeholder="Add an assertion here." dir="auto"></textarea></div>
+<div><textarea id="assertion" placeholder="Add an assertion here." dir="auto"></textarea></div>
 
 <div><textarea id="in" type="text" placeholder="Add text to be tested text here and click on GO." dir="auto"></textarea> 
 <button onClick="setText(document.getElementById('in').value)" id="go" style="vertical-align: top;">Go</button></div>

--- a/exploratory/text_decoration/int-text-decor.html
+++ b/exploratory/text_decoration/int-text-decor.html
@@ -178,7 +178,7 @@ for (let i=0;i<tests.length;i++) tests[i].style.writingMode = value
 
 
 <!-- INPUT AREA -->
-<div><textarea id="assertion" type="text" placeholder="Add an assertion here." dir="auto"></textarea></div>
+<div><textarea id="assertion" placeholder="Add an assertion here." dir="auto"></textarea></div>
 <div><textarea id="in" dir="auto" type="text" placeholder="Add text to be tested text here and click on GO."></textarea> 
 <button onClick="setText(document.getElementById('in').value)" id="go" style="vertical-align: top;">Go</button></div>
 

--- a/exploratory/text_decoration/int-text-emphasis.html
+++ b/exploratory/text_decoration/int-text-emphasis.html
@@ -108,7 +108,7 @@ for (let i=0;i<tests.length;i++) tests[i].style.writingMode = value
 
 
 <!-- INPUT AREA -->
-<div><textarea id="assertion" type="text" placeholder="Add an assertion here." dir="auto"></textarea></div>
+<div><textarea id="assertion" placeholder="Add an assertion here." dir="auto"></textarea></div>
 
 <div><textarea id="in" dir="auto" type="text" placeholder="Add text to be tested text here and click on GO."></textarea> 
 <button onClick="setText(document.getElementById('in').value)" id="go" style="vertical-align: top;">Go</button></div>

--- a/exploratory/text_spacing/int-text-spacing.html
+++ b/exploratory/text_spacing/int-text-spacing.html
@@ -58,7 +58,7 @@ for (let i=0;i<tests.length;i++) tests[i].style.writingMode = value
 
 
 <!-- INPUT AREA -->
-<div><textarea id="assertion" type="text" placeholder="Add an assertion here." dir="auto"></textarea></div>
+<div><textarea id="assertion" placeholder="Add an assertion here." dir="auto"></textarea></div>
 
 <div><textarea id="in" dir="auto" type="text" placeholder="Add text to be tested text here and click on GO."></textarea> 
 <button onClick="setText(document.getElementById('in').value)" id="go" style="vertical-align: top;">Go</button></div>

--- a/exploratory/text_transform/int-text-transform.html
+++ b/exploratory/text_transform/int-text-transform.html
@@ -73,7 +73,7 @@ for (let i=0;i<tests.length;i++) tests[i].style.writingMode = value
 
 
 <!-- INPUT AREA -->
-<div><textarea id="assertion" type="text" placeholder="Add an assertion here." dir="auto"></textarea></div>
+<div><textarea id="assertion" placeholder="Add an assertion here." dir="auto"></textarea></div>
 
 <div><textarea id="in" dir="auto" type="text" placeholder="Add text to be tested text here and click on GO."></textarea> 
 <button onClick="setText(document.getElementById('in').value)" id="go" style="vertical-align: top;">Go</button></div>

--- a/exploratory/vanilla/index.html
+++ b/exploratory/vanilla/index.html
@@ -28,7 +28,7 @@ overflow: hidden;
 
 
 <!-- INPUT AREA -->
-<div><textarea id="assertion" type="text" placeholder="Add an assertion here." dir="auto"></textarea></div>
+<div><textarea id="assertion" placeholder="Add an assertion here." dir="auto"></textarea></div>
 <div><textarea id="in" type="text" placeholder="Add text to be tested text here and click on GO." dir="auto"></textarea> 
 <button onClick="setText(document.getElementById('in').value)" id="go" style="vertical-align: top;">Go</button></div>
 


### PR DESCRIPTION
It is not necessary to add `type="text"` to `textarea` elements.