### PR TITLE
Update the assertion of the Arabic font assignment

### DIFF
--- a/batches/default-font.json
+++ b/batches/default-font.json
@@ -1,6 +1,6 @@
 tests = []
 tests[0]=["default-font-001.html","HTML CJK font assignment","",'https://drafts.csswg.org/css-fonts-4/#font-style-matching',"[exploratory] [exploratory] When no font-family is applied using styling, east asian text labelled with different lang attributes will be displayed using different fonts"] 
 
-tests[1]=["default-font-002.html","HTML Arabic font assignment","",'https://drafts.csswg.org/css-fonts-4/#font-style-matching',"[exploratory] When no font-family is applied using styling, arabic text labelled with different lang attributes will be displayed using different fonts."] 
+tests[1]=["default-font-002.html","HTML Arabic font assignment","",'https://drafts.csswg.org/css-fonts-4/#font-style-matching',"[exploratory] When no font-family is applied using styling, unlabelled arabic text and arabic text labelled with lang attributes will be displayed using different fonts."] 
 
 tests[2]=['../../testend','','','','']

--- a/css-fonts/font-style-matching/default-font-002.html
+++ b/css-fonts/font-style-matching/default-font-002.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8"/>
 <title>HTML Arabic font assignment</title>
 <link rel="author" title="r12a" href="mailto:ishida@w3.org"/>
-<meta name="assert" content="[exploratory] When no font-family is applied using styling, arabic text labelled with different lang attributes will be displayed using different fonts."/>
+<meta name="assert" content="[exploratory] When no font-family is applied using styling, unlabelled arabic text and arabic text labelled with lang attributes will be displayed using different fonts."/>
 <link rel="help" href="https://drafts.csswg.org/css-fonts-4/#font-style-matching">
 <style type="text/css">
  /* the following styles are not part of the test */


### PR DESCRIPTION
Test: https://www.w3.org/International/i18n-tests/results/default-font#arabic

The syntax highlighting of `batches/default-font.json` is not correct, because it is not a valid JSON file. Maybe the extension should be `.js`?